### PR TITLE
add netstat for fixing "Messkampange"

### DIFF
--- a/de.breitbandmessung.Breitbandmessung.metainfo.xml
+++ b/de.breitbandmessung.Breitbandmessung.metainfo.xml
@@ -7,7 +7,7 @@
   <url type="homepage">https://breitbandmessung.de/</url>
 
   <metadata_license>MIT</metadata_license>
-  <project_license>LicenseRef-proprietary=https://breitbandmessung.de/nutzungsbedingungen</project_license>
+  <project_license>LicenseRef-proprietary=https://breitbandmessung.de/nutzungsbedingungen AND GPL-2.0-only</project_license>
 
   <developer id="de.breitbandmessung">
     <name>zafaco GmbH</name>

--- a/de.breitbandmessung.Breitbandmessung.yml
+++ b/de.breitbandmessung.Breitbandmessung.yml
@@ -13,6 +13,22 @@ finish-args:
   - --socket=pulseaudio
   - --socket=x11
 modules:
+  - name: netstat
+    buildsystem: simple
+    build-commands:
+      # configure with default config
+      - yes '' | make config
+      - make netstat
+      - install -m 0755 netstat ${FLATPAK_DEST}/bin
+    sources:
+      - type: archive
+        url: https://sourceforge.net/projects/net-tools/files/net-tools-2.10.tar.xz
+        sha256: b262435a5241e89bfa51c3cabd5133753952f7a7b7b93f32e08cb9d96f580d69
+        x-checker-data:
+          type: html
+          url: https://sourceforge.net/projects/net-tools/rss
+          pattern: <link>(https://sourceforge.net/.+/net-tools-([\d\.]+\d).tar.xz)/download</link>
+
   - name: breitbandmessung
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
The app attempts to call `netstat -46 -rn | grep UG`, which fails without netstat in the bundle.

Fixes #1

**Note:**: Somehow the update check does not work properly. It constantly reports that it found a new version?

```
> flatpak run org.flathub.flatpak-external-data-checker ./de.breitbandmessung.Breitbandmessung.yml
...
INFO    src.lib.externaldata: Source net-tools-2.10.tar.xz: got new version 2.10
```
How do I fix that?