### PR TITLE
fix metadata linting errors

### DIFF
--- a/de.breitbandmessung.Breitbandmessung.metainfo.xml
+++ b/de.breitbandmessung.Breitbandmessung.metainfo.xml
@@ -3,11 +3,15 @@
   <id>de.breitbandmessung.Breitbandmessung</id>
 
   <name>Breitbandmessung</name>
-  <summary>Allows to measure internet speed.</summary>
+  <summary>Allows to measure internet speed</summary>
   <url type="homepage">https://breitbandmessung.de/</url>
 
   <metadata_license>MIT</metadata_license>
   <project_license>LicenseRef-proprietary=https://breitbandmessung.de/nutzungsbedingungen</project_license>
+
+  <developer id="de.breitbandmessung">
+    <name>zafaco GmbH</name>
+  </developer>
 
   <description>
     <p>


### PR DESCRIPTION
This fixes the reports:
  "errors": [
      "appstream-missing-developer-name"
  ],
  "warnings": [
      "appstream-summary-ends-in-dot"
  ],

The name of the developer is taken from:

  https://www.breitbandmessung.de/impressum