### PR TITLE
feat: share DRI

### DIFF
--- a/de.breitbandmessung.Breitbandmessung.yml
+++ b/de.breitbandmessung.Breitbandmessung.yml
@@ -8,6 +8,7 @@ tags:
   - proprietary
 command: breitbandmessung
 finish-args:
+  - --device=dri
   - --share=ipc
   - --share=network
   - --socket=pulseaudio


### PR DESCRIPTION
This seems to be required on some platforms now, otherwise starting the app fails with:

```text
MESA: error: Failed to query drm device.
glx: failed to create dri3 screen
failed to load driver: iris
```